### PR TITLE
Fix to utilize the favicons disk for generating favicons

### DIFF
--- a/src/Listeners/GenerateFavicons.php
+++ b/src/Listeners/GenerateFavicons.php
@@ -5,6 +5,8 @@ namespace Studio1902\PeakBrowserAppearance\Listeners;
 use Illuminate\Support\Facades\Artisan;
 use Statamic\Events\GlobalSetSaved;
 use Statamic\Globals\GlobalSet;
+use Illuminate\Support\Facades\Storage;
+use Statamic\Facades\URL;
 
 class GenerateFavicons
 {
@@ -38,17 +40,17 @@ class GenerateFavicons
         $svg = $globals->inDefaultSite()->get('svg');
         $background = $globals->inDefaultSite()->get('background');
 
-        $this->createThumbnail(public_path('favicons/') . $svg, public_path('favicons/icon-180.png'), 180, 180, $background, 15);
-        $this->createThumbnail(public_path('favicons/') . $svg, public_path('favicons/icon-512.png'), 512, 512, $background, 15);
-        $this->createThumbnail(public_path('favicons/') . $svg, public_path('favicons/favicon-16x16.png'), 16, 16, 'transparent', false);
-        $this->createThumbnail(public_path('favicons/') . $svg, public_path('favicons/favicon-32x32.png'), 32, 32, 'transparent', false);
+        $this->createThumbnail($svg, 'icon-180.png', 180, 180, $background, 15);
+        $this->createThumbnail($svg, 'icon-512.png', 512, 512, $background, 15);
+        $this->createThumbnail($svg, 'favicon-16x16.png', 16, 16, 'transparent', false);
+        $this->createThumbnail($svg, 'favicon-32x32.png', 32, 32, 'transparent', false);
 
         Artisan::call('cache:clear');
     }
 
     private function createThumbnail($import, $export, $width, $height, $background, $border)
     {
-        $svg = file_get_contents($import);
+        $svg = file_get_contents(URL::makeAbsolute(Storage::disk('favicons')->url($import)));
         $svgObj = simplexml_load_string($svg);
         $viewBox = explode(' ', $svgObj['viewBox']);
         $viewBoxWidth = $viewBox[2];
@@ -81,7 +83,7 @@ class GenerateFavicons
         }
 
         $im->setImageFormat('png32');
-        file_put_contents($export, $im->getImageBlob());
+        Storage::disk('favicons')->put($export, $im->getImageBlob());
         $im->clear();
         $im->destroy();
     }


### PR DESCRIPTION
As discussed, this updates GenerateFavicons Listener so it uses Storage for loading and saving the favicons.

We have a disk setting in filesystems.php, so we might as well use it :)

I've tested this in a clean install with the default 'local storage' setting, and also with the disk set to using a s3 driver for Digital Ocean Spaces. Generates the favicons and stores them on the correct disk. And also loads them correctly in the frontend. 