### PR TITLE
Favicons per site

### DIFF
--- a/resources/views/manifest/manifest.antlers.html
+++ b/resources/views/manifest/manifest.antlers.html
@@ -9,12 +9,12 @@
     "theme_color": "{{ browser_appearance:theme_color }}"{{ /if }}{{ if browser_appearance:use_favicons }},
     "icons": [
         {
-            "src": "{{ browser_appearance:override_512 ? { glide:browser_appearance:override_512 width='512' height='512' fit='crop_focal' } : '/favicons/icon-512.png' }}",
+            "src": "{{ browser_appearance:override_512 ? { glide:browser_appearance:override_512 width='512' height='512' fit='crop_focal' } : '/favicons/{site:handle}/icon-512.png' }}",
             "sizes": "512x512",
             "type": "image/png"
         },
         {
-            "src": "{{ browser_appearance:override_180 ? { glide:browser_appearance:override_180 width='180' height='180' fit='crop_focal' } : '/favicons/icon-180.png' }}",
+            "src": "{{ browser_appearance:override_180 ? { glide:browser_appearance:override_180 width='180' height='180' fit='crop_focal' } : '/favicons/{site:handle}/icon-180.png' }}",
             "sizes": "180x180",
             "type": "image/png"
         }

--- a/resources/views/snippets/_browser_appearance.antlers.html
+++ b/resources/views/snippets/_browser_appearance.antlers.html
@@ -36,7 +36,7 @@
 {{ /if }}
 
 {{# manifest.json for PWA's. #}}
-<link rel="manifest" href="/site.webmanifest">
+<link rel="manifest" href="{{ route:manifest.{site:handle} }}">
 
 {{# A yielded JS section essential when you use the theme toggle (dark mode) preset. #}}
 {{ yield:theme_toggle }}

--- a/resources/views/snippets/_browser_appearance.antlers.html
+++ b/resources/views/snippets/_browser_appearance.antlers.html
@@ -30,8 +30,8 @@
         <link rel="icon" href="{{ glide:browser_appearance:safari_icon width='16' height='16' fit='crop_focal' }}" sizes="16x16">
         <link rel="icon" href="{{ glide:browser_appearance:safari_icon width='32' height='32' fit='crop_focal' }}" sizes="32x32">
     {{ else }}
-        <link rel="icon" href="/favicons/favicon-16x16.png" sizes="16x16">
-        <link rel="icon" href="/favicons/favicon-32x32.png" sizes="32x32">
+        <link rel="icon" href="/favicons/{{ site:handle }}/favicon-16x16.png" sizes="16x16">
+        <link rel="icon" href="/favicons/{{ site:handle }}/favicon-32x32.png" sizes="32x32">
     {{ /if }}
 {{ /if }}
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,15 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 
-// The Manifest route to the manifest.json
-Route::statamic('/site.webmanifest', 'statamic-peak-browser-appearance::manifest/manifest', [
-    'layout' => null,
-    'content_type' => 'application/json'
-]);
+Site::all()->each(function (\Statamic\Sites\Site $site) {
+    $relativeSiteUrl = URL::makeRelative($site->url());
+
+    // The Manifest route to the manifest.json
+    Route::statamic(URL::tidy($relativeSiteUrl . '/site.webmanifest'), 'statamic-peak-browser-appearance::manifest/manifest', [
+        'layout' => null,
+        'content_type' => 'application/json'
+    ]);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,5 +11,5 @@ Site::all()->each(function (\Statamic\Sites\Site $site) {
     Route::statamic(URL::tidy($relativeSiteUrl . '/site.webmanifest'), 'statamic-peak-browser-appearance::manifest/manifest', [
         'layout' => null,
         'content_type' => 'application/json'
-    ]);
+    ])->name('manifest.' . $site->handle());
 });

--- a/src/Commands/GenerateFavicons.php
+++ b/src/Commands/GenerateFavicons.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Studio1902\PeakBrowserAppearance\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use Statamic\Console\RunsInPlease;
+use Statamic\Facades\GlobalSet;
+use Statamic\Facades\Site;
+use Statamic\Facades\URL;
+use Statamic\Globals\Variables;
+
+class GenerateFavicons extends Command
+{
+    use RunsInPlease;
+
+    protected $signature = 'statamic:peak:generate-favicons';
+    protected $description = 'Generate the favicons for all the sites.';
+
+    public function handle()
+    {
+        $globals = GlobalSet::findByHandle('browser_appearance');
+
+        Site::all()?->each(function (\Statamic\Sites\Site $site) use ($globals) {
+            /** @var Variables $set */
+            $set = $globals->in($site->handle());
+
+            // Skip sites which do not use favicons
+            if (!$set->value('use_favicons')) {
+                return;
+            }
+
+            $svg = $set->value('svg');
+            $background = $set->value('background');
+
+            $this->createThumbnail($svg, $site->handle() . '/icon-180.png', 180, 180, $background, 15);
+            $this->createThumbnail($svg, $site->handle() . '/icon-512.png', 512, 512, $background, 15);
+            $this->createThumbnail($svg, $site->handle() . '/favicon-16x16.png', 16, 16, 'transparent', false);
+            $this->createThumbnail($svg, $site->handle() . '/favicon-32x32.png', 32, 32, 'transparent', false);
+        });
+
+        Artisan::call('cache:clear');
+    }
+
+    protected function createThumbnail($import, $export, $width, $height, $background, $border): void
+    {
+        $svg = file_get_contents(URL::makeAbsolute(Storage::disk('favicons')->url($import)));
+        $svgObj = simplexml_load_string($svg);
+        $viewBox = explode(' ', $svgObj['viewBox']);
+        $viewBoxWidth = $viewBox[2];
+        $viewBoxHeight = $viewBox[3];
+        if ($viewBoxWidth >= $viewBoxHeight) {
+            $ratio = $width / $viewBoxWidth;
+        } else {
+            $ratio = $height / $viewBoxHeight;
+        }
+
+        $img = new \Imagick();
+        $img->setResolution($viewBoxWidth * $ratio * 2, $viewBoxHeight * $ratio * 2);
+        $img->setBackgroundColor(new \ImagickPixel($background));
+        $img->readImageBlob($svg);
+        $img->resizeImage($viewBoxWidth * $ratio, $viewBoxHeight * $ratio, \Imagick::FILTER_LANCZOS, 1);
+
+        if ($viewBoxWidth >= $viewBoxHeight) {
+            $compensateHeight = $height - ($viewBoxHeight * $ratio);
+            $img->extentImage($width, $height - $compensateHeight / 2, 0, $compensateHeight * -.5);
+            $img->extentImage($width, $height, 0, 0);
+        } else {
+            $compensateWidth = $width - ($viewBoxWidth * $ratio);
+            $img->extentImage($width - $compensateWidth / 2, $height, $compensateWidth * -.5, 0);
+            $img->extentImage($width, $height, 0, 0);
+        }
+
+        if ($border) {
+            $img->borderImage($background, $border, $border);
+            $img->resizeImage($width, $height, \Imagick::FILTER_LANCZOS, 1);
+        }
+
+        $img->setImageFormat('png32');
+        Storage::disk('favicons')->put($export, $img->getImageBlob());
+        $img->clear();
+        $img->destroy();
+    }
+
+}

--- a/src/Generators/Favicons.php
+++ b/src/Generators/Favicons.php
@@ -1,24 +1,17 @@
 <?php
 
-namespace Studio1902\PeakBrowserAppearance\Commands;
+namespace Studio1902\PeakBrowserAppearance\Generators;
 
-use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
-use Statamic\Console\RunsInPlease;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Globals\Variables;
 
-class GenerateFavicons extends Command
+class Favicons
 {
-    use RunsInPlease;
-
-    protected $signature = 'statamic:peak:generate-favicons';
-    protected $description = 'Generate the favicons for all the sites.';
-
-    public function handle()
+    public static function generate(): void
     {
         $globals = GlobalSet::findByHandle('browser_appearance');
 
@@ -34,16 +27,16 @@ class GenerateFavicons extends Command
             $svg = $set->value('svg');
             $background = $set->value('background');
 
-            $this->createThumbnail($svg, $site->handle() . '/icon-180.png', 180, 180, $background, 15);
-            $this->createThumbnail($svg, $site->handle() . '/icon-512.png', 512, 512, $background, 15);
-            $this->createThumbnail($svg, $site->handle() . '/favicon-16x16.png', 16, 16, 'transparent', false);
-            $this->createThumbnail($svg, $site->handle() . '/favicon-32x32.png', 32, 32, 'transparent', false);
+            self::createThumbnail($svg, $site->handle() . '/icon-180.png', 180, 180, $background, 15);
+            self::createThumbnail($svg, $site->handle() . '/icon-512.png', 512, 512, $background, 15);
+            self::createThumbnail($svg, $site->handle() . '/favicon-16x16.png', 16, 16, 'transparent', false);
+            self::createThumbnail($svg, $site->handle() . '/favicon-32x32.png', 32, 32, 'transparent', false);
         });
 
         Artisan::call('cache:clear');
     }
 
-    protected function createThumbnail($import, $export, $width, $height, $background, $border): void
+    protected static function createThumbnail($import, $export, $width, $height, $background, $border): void
     {
         $svg = file_get_contents(URL::makeAbsolute(Storage::disk('favicons')->url($import)));
         $svgObj = simplexml_load_string($svg);

--- a/src/Generators/Favicons.php
+++ b/src/Generators/Favicons.php
@@ -13,7 +13,9 @@ class Favicons
 {
     public static function generate(): void
     {
-        $globals = GlobalSet::findByHandle('browser_appearance');
+        if (!($globals = GlobalSet::findByHandle('browser_appearance'))) {
+            return;
+        }
 
         Site::all()?->each(function (\Statamic\Sites\Site $site) use ($globals) {
             /** @var Variables $set */

--- a/src/Listeners/GenerateFavicons.php
+++ b/src/Listeners/GenerateFavicons.php
@@ -2,30 +2,18 @@
 
 namespace Studio1902\PeakBrowserAppearance\Listeners;
 
-use Illuminate\Support\Facades\Artisan;
 use Statamic\Events\GlobalSetSaved;
 use Statamic\Globals\GlobalSet;
+use Studio1902\PeakBrowserAppearance\Generators\Favicons;
 
 class GenerateFavicons
 {
-    /**
-     * Determine whether this event should be handled.
-     *
-     * @param GlobalSet $globals
-     * @return bool
-     */
     private function shouldHandle(GlobalSet $globals): bool
     {
         return $globals->handle() === 'browser_appearance';
     }
 
-    /**
-     * Handle the event.
-     *
-     * @param GlobalSetSaved $event
-     * @return void
-     */
-    public function handle(GlobalSetSaved $event)
+    public function handle(GlobalSetSaved $event): void
     {
         /** @var GlobalSet $globals */
         $globals = $event->globals;
@@ -34,6 +22,6 @@ class GenerateFavicons
             return;
         }
 
-        Artisan::call('statamic:peak:generate-favicons');
+        Favicons::generate();
     }
 }

--- a/src/Listeners/GenerateFavicons.php
+++ b/src/Listeners/GenerateFavicons.php
@@ -4,11 +4,7 @@ namespace Studio1902\PeakBrowserAppearance\Listeners;
 
 use Illuminate\Support\Facades\Artisan;
 use Statamic\Events\GlobalSetSaved;
-use Statamic\Facades\Site;
 use Statamic\Globals\GlobalSet;
-use Illuminate\Support\Facades\Storage;
-use Statamic\Facades\URL;
-use Statamic\Globals\Variables;
 
 class GenerateFavicons
 {
@@ -38,64 +34,6 @@ class GenerateFavicons
             return;
         }
 
-        Site::all()?->each(function (\Statamic\Sites\Site $site) use ($globals) {
-            /** @var Variables $set */
-            $set = $globals->in($site->handle());
-
-            // Skip sites which do not use favicons
-            if (!$set->value('use_favicons')) {
-                return;
-            }
-
-            $svg = $set->value('svg');
-            $background = $set->value('background');
-
-            $this->createThumbnail($svg, $site->handle().'/icon-180.png', 180, 180, $background, 15);
-            $this->createThumbnail($svg, $site->handle().'/icon-512.png', 512, 512, $background, 15);
-            $this->createThumbnail($svg, $site->handle().'/favicon-16x16.png', 16, 16, 'transparent', false);
-            $this->createThumbnail($svg, $site->handle().'/favicon-32x32.png', 32, 32, 'transparent', false);
-        });
-
-        Artisan::call('cache:clear');
-    }
-
-    private function createThumbnail($import, $export, $width, $height, $background, $border)
-    {
-        $svg = file_get_contents(URL::makeAbsolute(Storage::disk('favicons')->url($import)));
-        $svgObj = simplexml_load_string($svg);
-        $viewBox = explode(' ', $svgObj['viewBox']);
-        $viewBoxWidth = $viewBox[2];
-        $viewBoxHeight = $viewBox[3];
-        if ($viewBoxWidth >= $viewBoxHeight) {
-            $ratio = $width / $viewBoxWidth;
-        } else {
-            $ratio = $height / $viewBoxHeight;
-        }
-
-        $im = new \Imagick();
-        $im->setResolution($viewBoxWidth * $ratio * 2, $viewBoxHeight * $ratio * 2);
-        $im->setBackgroundColor(new \ImagickPixel($background));
-        $im->readImageBlob($svg);
-        $im->resizeImage($viewBoxWidth * $ratio, $viewBoxHeight * $ratio, \imagick::FILTER_LANCZOS, 1);
-
-        if ($viewBoxWidth >= $viewBoxHeight) {
-            $compensateHeight = $height - ($viewBoxHeight * $ratio);
-            $im->extentImage($width, $height - $compensateHeight / 2, 0, $compensateHeight * -.5);
-            $im->extentImage($width, $height, 0, 0);
-        } else {
-            $compensateWidth = $width - ($viewBoxWidth * $ratio);
-            $im->extentImage($width - $compensateWidth / 2, $height, $compensateWidth * -.5, 0);
-            $im->extentImage($width, $height, 0, 0);
-        }
-
-        if ($border) {
-            $im->borderImage($background, $border, $border);
-            $im->resizeImage($width, $height, \imagick::FILTER_LANCZOS, 1);
-        }
-
-        $im->setImageFormat('png32');
-        Storage::disk('favicons')->put($export, $im->getImageBlob());
-        $im->clear();
-        $im->destroy();
+        Artisan::call('statamic:peak:generate-favicons');
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,12 +13,18 @@ class ServiceProvider extends AddonServiceProvider
             GenerateFavicons::class,
         ],
     ];
+
+    protected $commands = [
+        \Studio1902\PeakBrowserAppearance\Commands\GenerateFavicons::class,
+    ];
+
     protected $routes = [
         'web' => __DIR__ . '/../routes/web.php',
     ];
 
     protected $updateScripts = [
         \Studio1902\PeakBrowserAppearance\Updates\UpdateBrowserAppearanceGlobals::class,
+        \Studio1902\PeakBrowserAppearance\Updates\UpdateFaviconsPath::class,
     ];
 
     public function bootAddon()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,8 @@ namespace Studio1902\PeakBrowserAppearance;
 use Statamic\Events\GlobalSetSaved;
 use Statamic\Providers\AddonServiceProvider;
 use Studio1902\PeakBrowserAppearance\Listeners\GenerateFavicons;
+use Studio1902\PeakBrowserAppearance\Updates\UpdateBrowserAppearanceGlobals;
+use Studio1902\PeakBrowserAppearance\Updates\UpdateFaviconsPath;
 
 class ServiceProvider extends AddonServiceProvider
 {
@@ -14,17 +16,13 @@ class ServiceProvider extends AddonServiceProvider
         ],
     ];
 
-    protected $commands = [
-        \Studio1902\PeakBrowserAppearance\Commands\GenerateFavicons::class,
-    ];
-
     protected $routes = [
         'web' => __DIR__ . '/../routes/web.php',
     ];
 
     protected $updateScripts = [
-        \Studio1902\PeakBrowserAppearance\Updates\UpdateBrowserAppearanceGlobals::class,
-        \Studio1902\PeakBrowserAppearance\Updates\UpdateFaviconsPath::class,
+        UpdateBrowserAppearanceGlobals::class,
+        UpdateFaviconsPath::class,
     ];
 
     public function bootAddon()

--- a/src/Updates/UpdateFaviconsPath.php
+++ b/src/Updates/UpdateFaviconsPath.php
@@ -2,7 +2,6 @@
 
 namespace Studio1902\PeakBrowserAppearance\Updates;
 
-use Illuminate\Support\Facades\Artisan;
 use Statamic\Facades\Asset;
 use Statamic\UpdateScripts\UpdateScript;
 use Studio1902\PeakBrowserAppearance\Generators\Favicons;

--- a/src/Updates/UpdateFaviconsPath.php
+++ b/src/Updates/UpdateFaviconsPath.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Studio1902\PeakBrowserAppearance\Updates;
+
+use Illuminate\Support\Facades\Artisan;
+use Statamic\Facades\Asset;
+use Statamic\UpdateScripts\UpdateScript;
+
+class UpdateFaviconsPath extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('3.3.0');
+    }
+
+    public function update()
+    {
+        $this->deleteOldIcons();
+        $this->generateIcons();
+        $this->console()->info('Favicon paths adjusted.');
+    }
+
+    protected function deleteOldIcons(): void
+    {
+        $icons = collect([
+            'icon-180.png',
+            'icon-512.png',
+            'favicon-16x16.png',
+            'favicon-32x32.png',
+        ]);
+
+        Asset::whereFolder('/', 'favicons')
+            ?->filter(fn(\Statamic\Assets\Asset $asset) => $icons->contains($asset->path()))
+            ->each
+            ->delete();
+    }
+
+    protected function generateIcons(): void
+    {
+        Artisan::call('statamic:peak:generate-favicons');
+    }
+}

--- a/src/Updates/UpdateFaviconsPath.php
+++ b/src/Updates/UpdateFaviconsPath.php
@@ -5,15 +5,17 @@ namespace Studio1902\PeakBrowserAppearance\Updates;
 use Illuminate\Support\Facades\Artisan;
 use Statamic\Facades\Asset;
 use Statamic\UpdateScripts\UpdateScript;
+use Studio1902\PeakBrowserAppearance\Generators\Favicons;
 
 class UpdateFaviconsPath extends UpdateScript
 {
-    public function shouldUpdate($newVersion, $oldVersion)
+    public function shouldUpdate($newVersion, $oldVersion): bool
     {
-        return $this->isUpdatingTo('3.3.0');
+//        return $this->isUpdatingTo('3.3.0');
+        return true;
     }
 
-    public function update()
+    public function update(): void
     {
         $this->deleteOldIcons();
         $this->generateIcons();
@@ -31,12 +33,11 @@ class UpdateFaviconsPath extends UpdateScript
 
         Asset::whereFolder('/', 'favicons')
             ?->filter(fn(\Statamic\Assets\Asset $asset) => $icons->contains($asset->path()))
-            ->each
-            ->delete();
+            ->each->delete();
     }
 
     protected function generateIcons(): void
     {
-        Artisan::call('statamic:peak:generate-favicons');
+        Favicons::generate();
     }
 }

--- a/src/Updates/UpdateFaviconsPath.php
+++ b/src/Updates/UpdateFaviconsPath.php
@@ -11,8 +11,7 @@ class UpdateFaviconsPath extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion): bool
     {
-//        return $this->isUpdatingTo('3.3.0');
-        return true;
+        return $this->isUpdatingTo('3.3.0');
     }
 
     public function update(): void


### PR DESCRIPTION
Fixes #7.

Changes proposed in this pull request:
- Allow sites to have their own favicons
- Make `/site.webmanifest` route available for all sites

Stuff to discuss with @robdekort :

- [x] How should existing favicons/icons be migrated? => delete existing and trigger the generator on update
- [x] Decide if it's easier to generate favicons for each site or implement inheritance for sites with origins => per site
- [x] Should the `site.webmanifest` only be available for the default site? => nope, for each site