### PR TITLE
Register `site.webmanifest` routes with site specific url

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,11 +4,14 @@ use Illuminate\Support\Facades\Route;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 
-Site::all()->each(function (\Statamic\Sites\Site $site) {
+$sitesCount = Site::all()->count();
+
+Site::all()->each(function (\Statamic\Sites\Site $site) use ($sitesCount) {
     $relativeSiteUrl = URL::makeRelative($site->url());
 
     // The Manifest route to the manifest.json
-    Route::statamic(URL::tidy($relativeSiteUrl . '/site.webmanifest'), 'statamic-peak-browser-appearance::manifest/manifest', [
+    $manifest = $sitesCount === 1 ? 'site.webmanifest' : $site->handle() . '/site.webmanifest';
+    Route::statamic(URL::tidy($relativeSiteUrl . '/' . $manifest), 'statamic-peak-browser-appearance::manifest/manifest', [
         'layout' => null,
         'content_type' => 'application/json'
     ])->name('manifest.' . $site->handle());


### PR DESCRIPTION
Changes proposed in this pull request:
- Register `site.webmanifest` routes with site specific url
