### PR TITLE
Prevent manifest routes from having double handles

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,16 +3,17 @@
 use Illuminate\Support\Facades\Route;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
+use Stringy\StaticStringy as Stringy;
 
 Site::all()->each(function (\Statamic\Sites\Site $site) {
     $relativeSiteUrl = URL::makeRelative($site->url());
 
     // The Manifest route to the manifest.json
-    $manifest = Site::all()->count() === 1
-        ? 'site.webmanifest'
-        : $site->handle() . '/site.webmanifest';
+    $manifestUrl = Site::all()->count() === 1
+        ? $relativeSiteUrl . '/site.webmanifest'
+        : Stringy::ensureRight($relativeSiteUrl, '/' . $site->handle()) . '/site.webmanifest';
 
-    Route::statamic(URL::tidy($relativeSiteUrl . '/' . $manifest), 'statamic-peak-browser-appearance::manifest/manifest', [
+    Route::statamic(URL::tidy($manifestUrl), 'statamic-peak-browser-appearance::manifest/manifest', [
         'layout' => null,
         'content_type' => 'application/json'
     ])->name('manifest.' . $site->handle());


### PR DESCRIPTION
Given a multisite where the two sites get served under `/` and `/en`. Until now the manifest routes would be `/nl/site.webmanifest` and `/en/en/site.webmanifest`. 

The doubled `/en/en` is technically correct but ugly. This PR replaces those double handles.

Changes proposed in this pull request:
- Prevent doubled site handles in manifest routes
